### PR TITLE
Various changes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+Makefile
+Makefile.in
+lib*
+unit*
+*.o
+src/*.lo
+src/*.o
+src/.deps
+src/.dirstamp
+src/.libs

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,17 @@
+# If you use Automake then please delete the "makefile". Automake creates
+# a "Makefile" (upper-case M), but as long as "makefile" (lower-case M) exists
+# then "makefile" will be used and the Automake-"Makefile" is ignored.
+
+# INCLUDES = 
+AM_CPPFLAGS = -Iinclude
+
+noinst_LTLIBRARIES = libsimdcomp.la
+
+libsimdcomp_la_SOURCES = src/simdbitpacking.c \
+						 src/simdcomputil.c \
+						 src/simdintegratedbitpacking.c \
+						 include/simdbitpacking.h \
+						 include/simdcomp.h \
+						 include/simdcomputil.h \
+						 include/simdintegratedbitpacking.h
+

--- a/include/simdcomp.h
+++ b/include/simdcomp.h
@@ -5,8 +5,16 @@
 #ifndef SIMDCOMP_H_
 #define SIMDCOMP_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "simdbitpacking.h"
 #include "simdcomputil.h"
 #include "simdintegratedbitpacking.h"
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif 

--- a/include/simdcomputil.h
+++ b/include/simdcomputil.h
@@ -25,6 +25,10 @@ enum{ SIMDBlockSize = 128};
    and using differential coding */
 uint32_t simdmaxbitsd1(uint32_t initvalue, const uint32_t * in);
 
+/* like simdmaxbitsd1, but calculates maxbits over |length| integers 
+   with provided initial value. |length| can be any arbitrary value. */
+uint32_t simdmaxbitsd1_length(uint32_t initvalue, const uint32_t * in,
+                uint32_t length);
 
 
 

--- a/src/simdcomputil.c
+++ b/src/simdcomputil.c
@@ -1,4 +1,5 @@
 #include "simdcomputil.h"
+#include <assert.h>
 
 #define Delta(curr, prev) \
     _mm_sub_epi32(curr, \
@@ -53,18 +54,40 @@ uint32_t simdmaxbitsd1(uint32_t initvalue, const uint32_t * in) {
 
 
 /* maxbit over |length| integers with provided initial value */
-uint32_t simdmaxbitsd1givenlength(uint32_t initvalue, const uint32_t * in,
+uint32_t simdmaxbitsd1_length(uint32_t initvalue, const uint32_t * in,
                 uint32_t length) {
-    __m128i initoffset = _mm_set1_epi32(initvalue);
-    const __m128i *pin = (const __m128i *)(in);
-    __m128i newvec = _mm_load_si128(pin);
-    __m128i accumulator = Delta(newvec, initoffset);
-    __m128i oldvec = newvec;
+    __m128i newvec;
+    __m128i oldvec;
+    __m128i initoffset;
+    __m128i accumulator;
+    const __m128i *pin;
     uint32_t tmparray[4];
-    /* process 4 integers and build an accumulator */
     uint32_t k = 1;
     uint32_t acc;
-    while (k * 4 + 4 < length) {
+
+    assert(length > 0);
+
+    pin = (const __m128i *)(in);
+    initoffset = _mm_set1_epi32(initvalue);
+    switch (length) {
+      case 1:
+        newvec = _mm_set1_epi32(in[0]);
+        break;
+      case 2:
+        newvec = _mm_setr_epi32(in[0], in[1], in[1], in[1]);
+        break;
+      case 3:
+        newvec = _mm_setr_epi32(in[0], in[1], in[2], in[2]);
+        break;
+      default:
+        newvec = _mm_load_si128(pin);
+        break;
+    }
+    accumulator = Delta(newvec, initoffset);
+    oldvec = newvec;
+
+    /* process 4 integers and build an accumulator */
+    while (k * 4 + 4 <= length) {
         newvec = _mm_load_si128(pin + k);
         accumulator = _mm_or_si128(accumulator, Delta(newvec, oldvec));
         oldvec = newvec;

--- a/src/unit.c
+++ b/src/unit.c
@@ -6,7 +6,7 @@
 #include "simdcomp.h"
 
 
-int main() {
+int test() {
     int N = 5000 * SIMDBlockSize, gap;
     __m128i * buffer = malloc(SIMDBlockSize * sizeof(uint32_t));
     uint32_t * datain = malloc(N * sizeof(uint32_t));
@@ -63,5 +63,49 @@ int main() {
     free(datain);
     free(backbuffer);
     printf("Code looks good.\n");
+    return 0;
+}
+
+#define MAX 300
+int test_simdmaxbitsd1_length() {
+    uint32_t result, buffer[MAX + 1];
+    int i, j;
+
+    memset(&buffer[0], 0xff, sizeof(buffer));
+
+    /* this test creates buffers of different length; each buffer is
+     * initialized to result in the following deltas:
+     * length 1: 2
+     * length 2: 1 2
+     * length 3: 1 1 2
+     * length 4: 1 1 1 2
+     * length 5: 1 1 1 1 2
+     * etc. Each sequence's "maxbits" is 2. */
+    for (i = 0; i < MAX; i++) {
+      for (j = 0; j < i; j++)
+        buffer[j] = j + 1;
+      buffer[i] = i + 2;
+
+      result = simdmaxbitsd1_length(0, &buffer[0], i + 1);
+      if (result != 2) {
+        printf("simdmaxbitsd1_length: unexpected result %u in loop %d\n",
+                result, i);
+        return -1;
+      }
+    }
+    printf("simdmaxbitsd1_length: ok\n");
+    return 0;
+}
+
+int main() {
+    int r;
+   
+    r = test();
+    if (r)
+        return r;
+
+    r = test_simdmaxbitsd1_length();
+    if (r)
+        return r;
     return 0;
 }


### PR DESCRIPTION
Hi Daniel,

a couple of changes: improving C++ compatibility and C98 compatibility, and the simdmaxbitsd1_length function was buggy. I fixed the bug and also added a unittest.
The Automake-Makefile and the .gitignore file are not important; you don't have to merge them unless you find them helpful.

I thought about implementing functions for compressing and decompressing blocks < 128 integers, but this looks like lots of effort, and i'm a bit hesitant to do that. The current functions work well with underfilled blocks as long as the "maxbits" is calculated correctly with simdmaxbitsd1_length(). 

Best Regards
Christoph