### PR TITLE
Fixed bug when calling simdfastset with 32bits

### DIFF
--- a/src/simdbitpacking.c
+++ b/src/simdbitpacking.c
@@ -14131,8 +14131,15 @@ void simdfastset(__m128i * in128, uint32_t b, uint32_t value, size_t index) {
     const int secondwordinlane = (bitsinlane + b - 1) / 32;
     const uint32_t mask = (1 << b) - 1;
 
-    in[4 * firstwordinlane + lane] &= ~(mask << (bitsinlane % 32));/* we zero */
-    in[4 * firstwordinlane + lane] |= (value << (bitsinlane % 32));/* we write */
+    /* we zero */
+    if (b == 32)
+      in[4 * firstwordinlane + lane] = 0;
+    else
+      in[4 * firstwordinlane + lane] &= ~(mask << (bitsinlane % 32));
+
+    /* we write */
+    in[4 * firstwordinlane + lane] |= (value << (bitsinlane % 32));
+
     if (firstwordinlane == secondwordinlane) {
         /* easy common case*/
         return;


### PR DESCRIPTION
if b == 32 then mask = 0 and bitsinlane % 32 = 0. The "we zero" has no effect, and writing the new value leads to a corrupt result.